### PR TITLE
Add simple example using API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,40 @@ Personality Chat matches the user's small talk query with a small talk scenario.
 
 Check out the [Editorial Scenarios and sample query for Personality Chat](EditorialScenarioList.md)
 
+## Using the API directly
+
+> This API does not require subscription key.
+
+Request:
+```
+POST https://smarttalk.azure-api.net/api/v1/botframework HTTP/1.1
+Content-Type: application/json
+
+{
+    "query": "Hi, how are you?",
+    "persona": 0
+}
+```
+
+Response:
+```json
+{
+    "ScenarioList": [
+        {
+            "ScenarioName": "Greetings_HowAreYou",
+            "Score": 0.46,
+            "Responses": [
+                "Awesome, thanks.",
+                "I'm good.",
+                "I'm great."
+            ]
+        }
+    ],
+    "IsChatQuery": true,
+    "IsAdult": false,
+    "ElapsedMilliseconds": 764
+}
+```
 
 ### Throttling limits
 We enforce throttling limits on the Personality Chat API at the rate of 30 queries per minute. Throttling is done based on the IP address. 


### PR DESCRIPTION
This improves documentation by showing how simple it is to get started using the Personality chat API directly. This enables it to be used in any language and any context. It also gives clear expectations for developer that a subscription key is not required and what the response body will look like.

The existing documentation says:
> If you are interested in learning more about Project Personality Chat, or would like to participate in a private preview of the API, please contact us at personalitychat@microsoft.com 

But it is apparently public now and doesn't not need an invite.

Also, the link to learn the API just links to a CSharp file which isn't helpful.  People have to manually navigate multiple files to understand request object, enum values, and response.