### PR TITLE
Update to Bot Sdk v4.2.0, dotnetcore 2.2.0, add exception feedback for emulator channel

### DIFF
--- a/CSharp/PersonalityChat/Library/Microsoft.Bot.Builder.PersonalityChat.csproj
+++ b/CSharp/PersonalityChat/Library/Microsoft.Bot.Builder.PersonalityChat.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.PersonalityChat.Core" Version="1.0.0-alpha-m1.0" />
   </ItemGroup>
 </Project>

--- a/CSharp/PersonalityChat/Library/Microsoft.Bot.Builder.PersonalityChat.nuspec
+++ b/CSharp/PersonalityChat/Library/Microsoft.Bot.Builder.PersonalityChat.nuspec
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="9.0.1" />
-      <dependency id="Microsoft.Bot.Builder.Integration.AspNet.Core" version="4.0.0-alpha-m3.1" />
+      <dependency id="Microsoft.Bot.Builder.Integration.AspNet.Core" version="4.2.0" />
       <dependency id="Microsoft.Bot.Builder.PersonalityChat.Core" version="1.0.0-alpha-m1.0" />
     </dependencies>
   </metadata>

--- a/CSharp/PersonalityChat/Library/PersonalityChatMiddleware.cs
+++ b/CSharp/PersonalityChat/Library/PersonalityChatMiddleware.cs
@@ -71,10 +71,19 @@ namespace Microsoft.Bot.Builder.PersonalityChat
                             await this.PostPersonalityChatResponseToUser(turnContext, next, personalityChatResponse);
                         }
                     }
-                } catch (Exception ex)
+                }
+                catch (Exception ex)
                 {
-                    Console.WriteLine("Received exception - " + ex.Message);
-                    await this.PostPersonalityChatResponseToUser(turnContext, next, ex.Message);
+                    // For emulator use, send the Exception message
+                    if (turnContext.Activity.ChannelId == "emulator")
+                    {
+                        var response = $"PersonalityChatError: {ex.Message}";
+                        await this.PostPersonalityChatResponseToUser(turnContext, next, response);
+                    }
+                    else
+                    {
+                        throw;
+                    }
                 }
             }
 

--- a/CSharp/PersonalityChat/Samples/PersonalityChatBotWithCustomResponses/Microsoft.Bot.Builder.PersonalityChat.Sample.CustomResponses.csproj
+++ b/CSharp/PersonalityChat/Samples/PersonalityChatBotWithCustomResponses/Microsoft.Bot.Builder.PersonalityChat.Sample.CustomResponses.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.PersonalityChat.Core" Version="1.0.0-alpha-m1.0" />
   </ItemGroup>
 

--- a/CSharp/PersonalityChat/Samples/PersonalityChatBotWithCustomResponses/PersonalityChatBotCustomResponses.cs
+++ b/CSharp/PersonalityChat/Samples/PersonalityChatBotWithCustomResponses/PersonalityChatBotCustomResponses.cs
@@ -33,6 +33,7 @@
 
 namespace Microsoft.Bot.Builder.PersonalityChat.Sample.CustomResponses
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot;
     using Microsoft.Bot.Builder;
@@ -40,7 +41,7 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Sample.CustomResponses
 
     public class PersonalityChatBotCustomResponses : IBot
     {
-        public async Task OnTurn(ITurnContext context)
+        public async Task OnTurnAsync(ITurnContext context, CancellationToken cancellationToken = default(CancellationToken))
         {
             // At this point, the PersonalityChat Middleware has already been run. If the incoming
             // Activity was a message, the Middleware called out to PersonalityChat looking for 
@@ -53,7 +54,7 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Sample.CustomResponses
                     if (context.Activity.Type == ActivityTypes.Message && context.Responded == false)
                     {
                         // add app logic when Personality Chat didn't respond. 
-                        await context.SendActivity("Personality Chat didn't respond.");
+                        await context.SendActivityAsync("Personality Chat didn't respond.");
                     }
 
                     break;
@@ -62,12 +63,14 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Sample.CustomResponses
                     {
                         if (newMember.Id != context.Activity.Recipient.Id)
                         {
-                            await context.SendActivity("Hello and welcome to the Personality chat Sample bot.");
+                            await context.SendActivityAsync("Hello and welcome to the Personality chat Sample bot.");
                         }
                     }
 
                     break;
             }
         }
+
+        
     }
 }

--- a/CSharp/PersonalityChat/Samples/SimplePersonalityChatBot/BasicPersonalityChatBot.cs
+++ b/CSharp/PersonalityChat/Samples/SimplePersonalityChatBot/BasicPersonalityChatBot.cs
@@ -33,6 +33,7 @@
 
 namespace Microsoft.Bot.Builder.PersonalityChat.Sample.Basic
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Bot;
     using Microsoft.Bot.Builder;
@@ -40,7 +41,7 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Sample.Basic
 
     public class BasicPersonalityChatBot : IBot
     {
-        public async Task OnTurn(ITurnContext context)
+        public async Task OnTurnAsync(ITurnContext context, CancellationToken cancellationToken = default(CancellationToken))
         {
             // At this point, the PersonalityChat Middleware has already been run. If the incoming
             // Activity was a message, the Middleware called out to PersonalityChat looking for 
@@ -53,7 +54,7 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Sample.Basic
                     if (context.Activity.Type == ActivityTypes.Message && context.Responded == false)
                     {
                         // add app logic when Personality Chat didn't respond. 
-                        await context.SendActivity("Personality Chat didn't respond.");
+                        await context.SendActivityAsync("Personality Chat didn't respond.");
                     }
 
                     break;
@@ -62,12 +63,14 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Sample.Basic
                     {
                         if (newMember.Id != context.Activity.Recipient.Id)
                         {
-                            await context.SendActivity("Hello and welcome to the Personality chat Sample bot.");
+                            await context.SendActivityAsync("Hello and welcome to the Personality chat Sample bot.");
                         }
                     }
 
                     break;
             }
         }
+
+       
     }
 }

--- a/CSharp/PersonalityChat/Samples/SimplePersonalityChatBot/Microsoft.Bot.Builder.PersonalityChat.Sample.Basic.csproj
+++ b/CSharp/PersonalityChat/Samples/SimplePersonalityChatBot/Microsoft.Bot.Builder.PersonalityChat.Sample.Basic.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.PersonalityChat.Core" Version="1.0.0-alpha-m1.0" />
   </ItemGroup>
 

--- a/CSharp/PersonalityChat/Test/Microsoft.Bot.Builder.PersonalityChat.Tests.csproj
+++ b/CSharp/PersonalityChat/Test/Microsoft.Bot.Builder.PersonalityChat.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.0.0-alpha-m3.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.2.0" />
     <PackageReference Include="Microsoft.Bot.Builder.PersonalityChat.Core" Version="1.0.0-alpha-m1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharp/PersonalityChat/Test/PersonalityChatMiddlewareTests.cs
+++ b/CSharp/PersonalityChat/Test/PersonalityChatMiddlewareTests.cs
@@ -51,16 +51,16 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Tests
                     respondOnlyIfChat: false,
                     endActivityRoutingOnResponse: false)));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
                 if (context.Activity.Text == "test query aswedff")
                 {
-                    await context.SendActivity(context.Activity.Text);
+                    await context.SendActivityAsync(context.Activity.Text);
                 }
             })
                 .Send("test query aswedff")
                     .AssertReply("test response")
-                .StartTest();
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -71,13 +71,10 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Tests
                 .Use(new PersonalityChatMiddleware(new PersonalityChatMiddlewareOptions(
                     endActivityRoutingOnResponse: true)));
 
-            await new TestFlow(adapter, async (context) =>
-            {
-                await context.SendActivity(context.Activity.Text);
-            })
+            await new TestFlow(adapter, async (context, cancellationToken) => await context.SendActivityAsync(context.Activity.Text))
                 .Send("Hello")
                 .AssertReply("Hey. What's up?")
-                .StartTest();
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -89,14 +86,14 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Tests
                     new PersonalityChatMiddlewareOptions(
                         endActivityRoutingOnResponse: false)));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
-                await context.SendActivity(context.Activity.Text);
+                await context.SendActivityAsync(context.Activity.Text);
             })
                 .Send("Hello")
                 .AssertReply("Hey. What's up?")
                 .AssertReply("Hello")
-                .StartTest();
+                .StartTestAsync();
         }
 
         [TestMethod]
@@ -108,26 +105,26 @@ namespace Microsoft.Bot.Builder.PersonalityChat.Tests
                     new PersonalityChatMiddlewareOptions(
                         botPersona: PersonalityChatPersona.Professional)));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
-                await context.SendActivity(context.Activity.Text);
+                await context.SendActivityAsync(context.Activity.Text);
             })
                 .Send("Hello")
                 .AssertReply("Hello. What can I do for you?")
-                .StartTest();
+                .StartTestAsync();
 
             adapter = new TestAdapter()
                 .Use(new PersonalityChatMiddleware(
                     new PersonalityChatMiddlewareOptions(
                         botPersona: PersonalityChatPersona.Friendly)));
 
-            await new TestFlow(adapter, async (context) =>
+            await new TestFlow(adapter, async (context, cancellationToken) =>
             {
-                await context.SendActivity(context.Activity.Text);
+                await context.SendActivityAsync(context.Activity.Text);
             })
                 .Send("Hello")
                 .AssertReply("Hey. What's up?")
-                .StartTest();
+                .StartTestAsync();
         }
 
     }


### PR DESCRIPTION
Resolves #35

Also, returns exception message as a response when the `channelId == "emulator"`. I found the default behavior frustrating to figure out why the middleware wasn't working (timeouts from the service). #28 